### PR TITLE
Redux 테스트코드 작성을 위한 mocking을 추가

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+__mocks__

--- a/__mocks__/react-redux.ts
+++ b/__mocks__/react-redux.ts
@@ -1,0 +1,2 @@
+export const useDispatch = jest.fn();
+export const useSelector = jest.fn();

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,21 +1,21 @@
 module.exports = {
-    setupFilesAfterEnv: [
-      'given2/setup',
-      'jest-plugin-context/setup',
-      './jest.setup',
-    ],
-    coverageThreshold: {
-      global: {
-        branches: 100,
-        functions: 100,
-        lines: 100,
-        statements: 100,
-      },
+  setupFilesAfterEnv: [
+    'given2/setup',
+    'jest-plugin-context/setup',
+    './jest.setup',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
     },
-    coverageReporters: ['json-summary'],
-    testEnvironment: 'jsdom',
-    moduleNameMapper: {
-      '^@src(.*)$': '<rootDir>/src$1',
-    },
-  };
-  
+  },
+  coverageReporters: ['json-summary'],
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@src(.*)$': '<rootDir>/src$1',
+    '\\.(css|scss)$': 'identity-obj-proxy'
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,6 +60,7 @@
         "eslint-plugin-react-hooks": "^1.7.0",
         "given2": "^2.1.7",
         "html-webpack-plugin": "^5.3.2",
+        "identity-obj-proxy": "^3.0.0",
         "jest": "^27.2.0",
         "jest-plugin-context": "^2.9.0",
         "mini-css-extract-plugin": "^2.0.0",
@@ -19059,6 +19060,12 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
+    "node_modules/harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -19798,6 +19805,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "dependencies": {
+        "harmony-reflect": "^1.4.6"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ieee754": {
@@ -46228,6 +46247,12 @@
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
     },
+    "harmony-reflect": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/harmony-reflect/-/harmony-reflect-1.6.2.tgz",
+      "integrity": "sha512-HIp/n38R9kQjDEziXyDTuW3vvoxxyxjxFzXLrBr18uB47GnSt+G9D29fqrpM5ZkspMcPICud3XsBJQ4Y2URg8g==",
+      "dev": true
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -46813,6 +46838,15 @@
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
       "dev": true,
       "requires": {}
+    },
+    "identity-obj-proxy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz",
+      "integrity": "sha1-lNK9qWCERT7zb7xarsN+D3nx/BQ=",
+      "dev": true,
+      "requires": {
+        "harmony-reflect": "^1.4.6"
+      }
     },
     "ieee754": {
       "version": "1.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^17.0.2",
         "react-redux": "^7.2.5",
         "redux": "^4.1.1",
+        "redux-mock-store": "^1.5.4",
         "typescript": "^4.3.5"
       },
       "devDependencies": {
@@ -41,6 +42,7 @@
         "@types/react-dom": "^17.0.9",
         "@types/react-redux": "^7.1.18",
         "@types/redux": "^3.6.0",
+        "@types/redux-mock-store": "^1.0.3",
         "@typescript-eslint/eslint-plugin": "^4.31.1",
         "@typescript-eslint/parser": "^4.31.1",
         "babel-loader": "^8.2.2",
@@ -11693,6 +11695,15 @@
         "redux": "*"
       }
     },
+    "node_modules/@types/redux-mock-store": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.3.tgz",
+      "integrity": "sha512-Wqe3tJa6x9MxMN4DJnMfZoBRBRak1XTPklqj4qkVm5VBpZnC8PSADf4kLuFQ9NAdHaowfWoEeUMz7NWc2GMtnA==",
+      "dev": true,
+      "dependencies": {
+        "redux": "^4.0.5"
+      }
+    },
     "node_modules/@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -22965,6 +22976,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -26228,6 +26244,14 @@
       "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
       "dependencies": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "node_modules/redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "dependencies": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "node_modules/redux-thunk": {
@@ -40312,6 +40336,15 @@
         "redux": "*"
       }
     },
+    "@types/redux-mock-store": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/redux-mock-store/-/redux-mock-store-1.0.3.tgz",
+      "integrity": "sha512-Wqe3tJa6x9MxMN4DJnMfZoBRBRak1XTPklqj4qkVm5VBpZnC8PSADf4kLuFQ9NAdHaowfWoEeUMz7NWc2GMtnA==",
+      "dev": true,
+      "requires": {
+        "redux": "^4.0.5"
+      }
+    },
     "@types/scheduler": {
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
@@ -49133,6 +49166,11 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -51689,6 +51727,14 @@
       "integrity": "sha512-hZQZdDEM25UY2P493kPYuKqviVwZ58lEmGQNeQ+gXa+U0gYPUBf7NKYazbe3m+bs/DzM/ahN12DbF+NG8i0CWw==",
       "requires": {
         "@babel/runtime": "^7.9.2"
+      }
+    },
+    "redux-mock-store": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/redux-mock-store/-/redux-mock-store-1.5.4.tgz",
+      "integrity": "sha512-xmcA0O/tjCLXhh9Fuiq6pMrJCwFRaouA8436zcikdIpYWWCjU76CRk+i2bHx8EeiSiMGnB85/lZdU3wIJVXHTA==",
+      "requires": {
+        "lodash.isplainobject": "^4.0.6"
       }
     },
     "redux-thunk": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/react-dom": "^17.0.9",
     "@types/react-redux": "^7.1.18",
     "@types/redux": "^3.6.0",
+    "@types/redux-mock-store": "^1.0.3",
     "@typescript-eslint/eslint-plugin": "^4.31.1",
     "@typescript-eslint/parser": "^4.31.1",
     "babel-loader": "^8.2.2",
@@ -84,6 +85,7 @@
     "react-dom": "^17.0.2",
     "react-redux": "^7.2.5",
     "redux": "^4.1.1",
+    "redux-mock-store": "^1.5.4",
     "typescript": "^4.3.5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-react-hooks": "^1.7.0",
     "given2": "^2.1.7",
     "html-webpack-plugin": "^5.3.2",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^27.2.0",
     "jest-plugin-context": "^2.9.0",
     "mini-css-extract-plugin": "^2.0.0",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,21 +1,38 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { useDispatch, useSelector } from 'react-redux';
 
 import App from './App';
 
+jest.mock('react-redux');
 
-describe('App', () => {
-  function renderApp() {
-    return render(
-        <App />
+function renderApp() {
+  return render(<App />);
+}
+
+describe('<App>', () => {
+  const dispatch = jest.fn();
+
+  beforeEach(() => {
+    dispatch.mockClear();
+
+    (useDispatch as jest.MockedFunction<typeof useDispatch>).mockImplementation(
+      () => dispatch,
     );
-  }
 
-  context('컴포넌트가', () => {
-    it('정상적으로 렌더링된다', () => {
+    (useSelector as jest.MockedFunction<typeof useSelector>).mockImplementation(
+      (selector) =>
+        selector({
+          ui: { isLoading: true },
+        }),
+    );
+  });
+
+  context('컴포넌트에서', () => {
+    it('텍스트가 제대로 렌더링 되는지 확인한다', () => {
       const { container } = renderApp();
 
-      expect(container).toHaveTextContent('test');
+      expect(container).toHaveTextContent('toggleloading');
     });
   });
 });

--- a/src/store/uiSlice.test.ts
+++ b/src/store/uiSlice.test.ts
@@ -1,0 +1,20 @@
+import uiReducer, { setLoading } from './uiSlice';
+
+describe('uiReducer 에서', () => {
+  context('isLoading 프로퍼티의', () => {
+    it('값이 정상적으로 추가된다', () => {
+      const initialState = {
+        isLoading: false,
+      };
+
+      const state = uiReducer(
+        initialState,
+        setLoading({
+          isLoading: true,
+        }),
+      );
+
+      expect(state.isLoading).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Redux에 대한 mocking 처리를 하여 Provider를 사용하지 않고도 테스트 코드가 실행되도록 처리하였습니다.

## Detail
### redux-mock-store 모듈을 추가 https://github.com/mbti-builder/fe/commit/df5452125109e67972894f725f853dd18eaa7574
* reducer가 아닌 action에 대한 테스팅을 위한 모듈
### react-redux 가짜 함수를 정의 https://github.com/mbti-builder/fe/commit/dc9a106cc586dc638c56f3a2a77a418822c35305
* useSelector, useDispatch
* eslintignore에 추가
* https://velog.io/@yhe228/useSelector-%ED%95%A8%EC%88%98%EB%A5%BC-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%BD%94%EB%93%9C%EC%97%90%EC%84%9C-%EC%82%AC%EC%9A%A9%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%9
### uiReducer에 대한 테스트코드를 작성한다 https://github.com/mbti-builder/fe/commit/988015a1797d065de8ed34584963964fbb932f92
* 슬라이스 테스트
### mocking 함수를 이용해 App 컴포넌트의 테스트코드를 작성 https://github.com/mbti-builder/fe/commit/89900e4b71e2a77e35d29e1c68c7f1e1f6b4db3a
* 컴포넌트 테스트시 redux에 대한 부분을 정의하지 않으면 provider에 대한 오류가 발생
* action이 발생했는지에 대해서만 테스트 가능(fireEvent로 버튼 누르는 이벤트 발생시 눌렸는지 여부 - store에 변경된 값이 반영되진 않음..)

## Issue
현재 방식은 컴포넌트 테스트시 action이 발생했는지를 테스트하는 것이기 때문에 실제로 값이 바뀐것에 대해서는 반영이 되지 않습니다. 단, reducer에 대해 직접 테스트를 할 경우에는 store에 변경된 값을 기반으로 테스트를 작성할 수 있습니다.

https://dev.to/fredrikbergqvist/mocking-redux-useselector-hook-2ale 댓글을 보면 Provider를 직접 사용하는 방식도 존재합니다.