### PR TITLE
컴포넌트 테스트 스캐폴딩

### DIFF
--- a/.vscode/gwt.code-snippets
+++ b/.vscode/gwt.code-snippets
@@ -1,0 +1,16 @@
+{
+    "given-when-then": {
+        "scope": "typescript, typescriptreact",
+        "prefix": "gwt",
+        "body": [
+            "it('should (1)', () => {",
+            "    // Given (4)",
+            "",
+            "    // When (3)",
+            "",
+            "    // Then (2)",
+            "})"
+        ],
+        "description": "['이 스니펫은 -입니다' 설명]"
+    }
+}

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,21 +1,30 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, fireEvent, screen } from '@src/test-utils';
 
 import App from './App';
 
+describe('기본 test', () => {
+  it('컴포넌트는 정상적으로 렌더링되어야 한다.', () => {
+    const { container } = render(<App />)
+    expect(container).toBeInTheDocument();
+  })
+});
 
-describe('App', () => {
-  function renderApp() {
-    return render(
-        <App />
-    );
-  }
+describe('Redux 예시 test', () => {
+  beforeEach(() => { render(<App />); })
 
-  context('컴포넌트가', () => {
-    it('정상적으로 렌더링된다', () => {
-      const { container } = renderApp();
+  it('렌더링 되었을 때 default text는 break 이어야 한다.', () => {
+    expect(screen.getByText('break')).toBeInTheDocument();
+  });
 
-      expect(container).toHaveTextContent('test');
-    });
+  it('toggle 버튼을 클릭하면 text는 loading과 break 로 번갈아 변경되어야 한다.', () => {
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(screen.getByText('loading')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(screen.getByText('break')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'toggle' }));
+    expect(screen.getByText('loading')).toBeInTheDocument();
   });
 });

--- a/src/test-utils.tsx
+++ b/src/test-utils.tsx
@@ -1,0 +1,19 @@
+// code reference: https://redux.js.org/usage/writing-tests#components
+import React from 'react'
+import { render as rtlRender } from '@testing-library/react'
+import { Provider } from 'react-redux'
+
+// Import your own modules
+import store from '@src/store';
+
+const render = (component: React.ReactElement) => {
+    const Wrapper = ({ children }: { children?: React.ReactNode }) => {
+        return <Provider store={store}>{children}</Provider>
+    }
+    return rtlRender(component, { wrapper: Wrapper })
+}
+
+// re-export everything
+export * from '@testing-library/react'
+// override render method
+export { render }


### PR DESCRIPTION
## Summary
* 컴포넌트 테스트를 위한 세팅을 했습니다.

## Detail
* Redux 가 있는 경우 `<Provide /> ` 로 감싸져야 하기 때문에, 컴포넌트 테스트가 어렵습니다. 
  * 이를 해결하기 위해 매 테스트마다 Provider를 감싸주는 방법이 있습니다. 하지만 번거로운 방식입니다. 그래서 redux-toolkit [문서](https://redux.js.org/usage/writing-tests#components)를 참고해서 `test-utils.tsx` 함수를 만들어 중복되는 코드를 피하려고 했습니다.
* React Testing Library 를 활용해 예시 테스트를 작성했습니다.
* 원활한 테스트 작성을 위해 given when then 패턴을 위한 vscode user snippet 을 추가했습니다.

## Issue
* 컴포넌트 구조 설계가 필요한 시점 같습니다.