### PR TITLE
scss 절대경로 설정 및 variable, mixin 등 scss를 기본으로 import 하도록 설정

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require('path');
 
 const PROJECT_ROOT = path.resolve(__dirname, '../.');
 const SRC_PATH = path.resolve(PROJECT_ROOT, 'src');
@@ -6,12 +6,24 @@ const SRC_PATH = path.resolve(PROJECT_ROOT, 'src');
 module.exports = async ({ config }) => {
   config.module.rules.push({
     test: /\.s?css$/,
-    use: ["style-loader", "css-loader", "sass-loader"],
+    use: [
+      'style-loader',
+      'css-loader',
+      {
+        loader: 'sass-loader',
+        options: {
+          sassOptions: {
+            includePaths: [path.join(PROJECT_ROOT, './src/styles')],
+          },
+          additionalData: `@import "index";`,
+        },
+      },
+    ],
   });
 
   config.resolve.alias = {
     '@src': SRC_PATH,
-  }
+  };
 
   // don't forget to return.
   return config;

--- a/config/webpack/webpack.dev.js
+++ b/config/webpack/webpack.dev.js
@@ -20,7 +20,19 @@ module.exports = merge(baseConfig, {
     rules: [
       {
         test: /\.s?css$/,
-        use: ['style-loader', 'css-loader', 'sass-loader'],
+        use: [
+          'style-loader',
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                includePaths: [path.join(PROJECT_ROOT, './src/styles')],
+              },
+              additionalData: `@import "index";`,
+            },
+          },
+        ],
       },
     ],
   },

--- a/config/webpack/webpack.prod.js
+++ b/config/webpack/webpack.prod.js
@@ -15,7 +15,19 @@ module.exports = merge(baseConfig, {
     rules: [
       {
         test: /\.s?css$/,
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                includePaths: [path.join(PROJECT_ROOT, './src/styles')],
+              },
+              additionalData: `@import "index";`,
+            },
+          },
+        ],
       },
     ],
   },


### PR DESCRIPTION
## Summary
scss에서 @import 시 webpack에서 설정한 절대경로를 사용할 수 없었습니다.

## Detail
이와 관련하여 찾은 설정은 두가지인데 두개 모두 sass-loader의 option 입니다.

1. sassOptions.includePaths
  - 절대경로를 지정해줍니다. 예를들어 src/styles 경로를 지정해주면 어떤 위치에서든 `@import 'mixin';` 이런식으로 import 했을 때 해당 경로의 파일을 가져오게 됩니다.

2. additionalData
  - general한 scss(mixin, variable 등)를 기본으로 import 하도록 해줍니다. 예를들어 scss에서 variable이나 mixin 정의된 것을 사용하려면 일일이 import 해줘야 하는데 해당 설정을 미리 해두면 이것을 import 하지 않아도 사용할 수 있도록 해줍니다.

#### Reference
- https://webpack.js.org/loaders/sass-loader/#sassoptions
- https://webpack.js.org/loaders/sass-loader/#additionaldata
- https://stackoverflow.com/questions/35533428/webpack-sass-loader-does-not-recognize-global-variables-file