### PR TITLE
스토리북 continuous deploy용 action을 추가

### DIFF
--- a/.github/workflows/STORYBOOK_CD.yml
+++ b/.github/workflows/STORYBOOK_CD.yml
@@ -1,0 +1,59 @@
+name: Deploy storybook to gh-pages
+
+on:
+  push:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - run: npm ci
+      - run: npm run build-storybook
+
+
+      # extract branch name
+      - name: Get branch name (merge)
+        if: github.event_name != 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | sed 's/#//')" >> $GITHUB_ENV
+
+      - name: Get branch name (pull request)
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF} | sed 's/#//')" >> $GITHUB_ENV
+
+      - name: Debug
+        run: echo ${{ env.BRANCH_NAME }}
+
+      - name: Deploy to Github Pages(pr)
+        uses: peaceiris/actions-gh-pages@v3
+        if: env.BRANCH_NAME != 'master'
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          publish_dir: ./storybook-static
+          keep_files: true
+          destination_dir: ${{ env.BRANCH_NAME }}
+          commit_message: https://mbti-builder.github.io/fe/${{ env.BRANCH_NAME }}
+
+      - name: Deploy to Github Pages(master)
+        uses: peaceiris/actions-gh-pages@v3
+        if: env.BRANCH_NAME == 'master'
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          publish_dir: ./storybook-static
+          keep_files: true
+          commit_message: https://mbti-builder.github.io/fe/


### PR DESCRIPTION
## Summary
스토리북을 배포해서 확인하기 위한 용도로 사용하기 위한 github actions cd 를 추가하였습니다.

## Detail
각 branch에 push하면 `https://mbti-builder.github.io/fe/<브랜치명>` 이렇게 접근할 수 있도록 gh-pages 브랜치에 push된 브랜치 명으로 된 폴더를 만들어 빌드된 파일을 추가해 배포되도록 합니다.


https://mbti-builder.github.io/fe/env/storybook-cd/