### PR TITLE
ESLint의 react/jsx-props-no-spreading 설정을 off 한다

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "env": {
-      "browser": true,
-      "es2021": true
+    "browser": true,
+    "es2021": true
   },
   "extends": [
     "airbnb",
@@ -14,19 +14,15 @@
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-      "ecmaFeatures": {
-          "jsx": true
-      },
-      "ecmaVersion": 12,
-      "sourceType": "module",
-      "project": "./tsconfig.json",
-      "tsconfigRootDir": "./"
-  
+    "ecmaFeatures": {
+      "jsx": true
+    },
+    "ecmaVersion": 12,
+    "sourceType": "module",
+    "project": "./tsconfig.json",
+    "tsconfigRootDir": "./"
   },
-  "plugins": [
-      "react",
-      "@typescript-eslint"
-  ],
+  "plugins": ["react", "@typescript-eslint"],
   "rules": {
     "import/extensions": [
       "error",
@@ -38,19 +34,23 @@
         "tsx": "never"
       }
     ],
-    "react/jsx-filename-extension": [2, { "extensions": [".js", ".jsx", ".ts", ".tsx"] }],
+    "react/jsx-filename-extension": [
+      2,
+      { "extensions": [".js", ".jsx", ".ts", ".tsx"] }
+    ],
     "no-param-reassign": "off",
     "no-use-before-define": "off",
     "react/react-in-jsx-scope": "off",
     "@typescript-eslint/no-use-before-define": ["error"],
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/explicit-module-boundary-types": "off",
-    "import/no-extraneous-dependencies": "off"
+    "import/no-extraneous-dependencies": "off",
+    "react/jsx-props-no-spreading": "off"
   },
   "settings": {
     "import/resolver": {
       "node": {
-        "extensions" : [".js", ".jsx", ".ts", ".tsx"]
+        "extensions": [".js", ".jsx", ".ts", ".tsx"]
       },
       "typescript": "./tsconfig.json"
     }


### PR DESCRIPTION
## Summary
https://github.com/mbti-builder/fe/pull/26#discussion_r711759431 에서 의논한 결과 lint ignore 주석이 늘어날 것 같아 해당 rule을 off 시키는 것으로 합의가 되었습니다.

## Detail
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-props-no-spreading.md

