### PR TITLE
공통으로 사용될 Skeleton 컴포넌트 제작

### DIFF
--- a/src/atom/Skeleton/Skeleton.scss
+++ b/src/atom/Skeleton/Skeleton.scss
@@ -2,7 +2,7 @@
   display: block;
   background-color: rgba(0, 0, 0, 0.15);
   height: auto;
-  border-radius: 6px;
+  border-radius: 0.6rem;
 
   // variant
   &.circle {
@@ -63,32 +63,32 @@
 
   // size
   &.xxs {
-    width: 32px;
-    height: 24px;
+    width: 3.2rem;
+    height: 2.4rem;
   }
   &.xs {
-    width: 40px;
-    height: 28px;
+    width: 4rem;
+    height: 2.8rem;
   }
   &.sm {
-    width: 60px;
-    height: 32px;
+    width: 6rem;
+    height: 3.2rem;
   }
   &.md {
-    width: 80px;
-    height: 36px;
+    width: 8rem;
+    height: 3.6rem;
   }
   &.lg {
-    width: 100px;
-    height: 44px;
+    width: 10rem;
+    height: 4.4rem;
   }
   &.xl {
-    width: 140px;
-    height: 56px;
+    width: 14rem;
+    height: 5.6rem;
   }
   &.xxl {
-    width: 200px;
-    height: 88px;
+    width: 20rem;
+    height: 8.8rem;
   }
 
   // fitContent

--- a/src/atom/Skeleton/Skeleton.scss
+++ b/src/atom/Skeleton/Skeleton.scss
@@ -1,0 +1,105 @@
+._SKELETON_ {
+  display: block;
+  background-color: rgba(0, 0, 0, 0.15);
+  height: auto;
+  border-radius: 6px;
+
+  // variant
+  &.circle {
+    border-radius: 50%;
+  }
+
+  // animation
+  &.wave {
+    position: relative;
+    overflow: hidden;
+    &::after {
+      position: absolute;
+      content: '';
+      top: 0;
+      left: 0;
+      bottom: 0;
+      right: 0;
+      background: linear-gradient(
+        90deg,
+        transparent,
+        rgba(#fff, 0.3) 60%,
+        transparent
+      );
+      transform: translateX(-100%);
+      animation: wave 1.6s linear 0.8s infinite;
+    }
+  }
+  @keyframes wave {
+    0% {
+      transform: translateX(-100%);
+    }
+    60% {
+      transform: translateX(100%);
+    }
+    100% {
+      transform: translateX(100%);
+    }
+  }
+
+  &.pulse {
+    animation: pulse 1.5s ease-in-out 0.5s infinite;
+  }
+  @keyframes pulse {
+    0% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.4;
+    }
+    100% {
+      opacity: 1;
+    }
+  }
+
+  &.false {
+    animation: none;
+  }
+
+  // size
+  &.xxs {
+    width: 32px;
+    height: 24px;
+  }
+  &.xs {
+    width: 40px;
+    height: 28px;
+  }
+  &.sm {
+    width: 60px;
+    height: 32px;
+  }
+  &.md {
+    width: 80px;
+    height: 36px;
+  }
+  &.lg {
+    width: 100px;
+    height: 44px;
+  }
+  &.xl {
+    width: 140px;
+    height: 56px;
+  }
+  &.xxl {
+    width: 200px;
+    height: 88px;
+  }
+
+  // fitContent
+  &.fitContent {
+    max-width: fit-content;
+  }
+
+  // withChildren
+  &.withChildren {
+    & > * {
+      visibility: hidden;
+    }
+  }
+}

--- a/src/atom/Skeleton/Skeleton.stories.tsx
+++ b/src/atom/Skeleton/Skeleton.stories.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import Skeleton from '@src/atom/Skeleton';
+
+export default {
+  title: 'Skeleton',
+  component: Skeleton,
+  argTypes: {
+    size: {
+      options: ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'],
+      control: { type: 'radio' },
+    },
+  },
+} as Meta;
+
+const Template: Story = (props) => <Skeleton {...props} />;
+
+export const skeleton = Template.bind({});
+
+skeleton.args = {
+  variant: 'rect',
+  animation: 'wave',
+  size: 'xl',
+  fitContent: false,
+  withChildren: false,
+};

--- a/src/atom/Skeleton/Skeleton.test.tsx
+++ b/src/atom/Skeleton/Skeleton.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render, getByTestId } from '@src/test-utils';
 import Skeleton, { SkeletonProps } from '@src/atom/Skeleton';
 
+const testQuote = `"I find the harder I work, the more luck I have" - Thomas Jefferson`;
+
 function renderInput(props: SkeletonProps) {
   return render(<Skeleton {...props} />);
 }
@@ -26,9 +28,23 @@ describe('<Skeleton />', () => {
       const { container } = renderInput({ size: 'md' });
       expect(getByTestId(container, 'skeleton')).toHaveClass('md');
     });
-    it('children props를 넘기면 컴포넌트에 반영된다', () => {
-      const { container } = renderInput({ children: 'test' });
-      expect(getByTestId(container, 'skeleton')).toHaveTextContent('test');
+    context('children props를 넘기면', () => {
+      it('withChildren이 true일 때 컴포넌트에 반영된다', () => {
+        const { container } = renderInput({
+          withChildren: true,
+          children: testQuote,
+        });
+        expect(getByTestId(container, 'skeleton')).toHaveTextContent(testQuote);
+      });
+      it('withChildren이 false일 때 컴포넌트에 반영되지 않는다', () => {
+        const { container } = renderInput({
+          withChildren: false,
+          children: 'test',
+        });
+        expect(getByTestId(container, 'skeleton')).toEqual(
+          expect.not.stringContaining(testQuote),
+        );
+      });
     });
   });
 });

--- a/src/atom/Skeleton/Skeleton.test.tsx
+++ b/src/atom/Skeleton/Skeleton.test.tsx
@@ -39,7 +39,7 @@ describe('<Skeleton />', () => {
       it('withChildren이 false일 때 컴포넌트에 반영되지 않는다', () => {
         const { container } = renderInput({
           withChildren: false,
-          children: 'test',
+          children: testQuote,
         });
         expect(getByTestId(container, 'skeleton')).toEqual(
           expect.not.stringContaining(testQuote),

--- a/src/atom/Skeleton/Skeleton.test.tsx
+++ b/src/atom/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, getByTestId } from '@src/test-utils';
+import Skeleton, { SkeletonProps } from '@src/atom/Skeleton';
+
+function renderInput(props: SkeletonProps) {
+  return render(<Skeleton {...props} />);
+}
+
+describe('<Skeleton />', () => {
+  it('컴포넌트는 정상적으로 렌더링되어야 한다.', () => {
+    const { container } = renderInput({});
+    expect(container).toBeInTheDocument();
+    expect(getByTestId(container, 'skeleton')).toHaveClass('_SKELETON_');
+  });
+
+  context('props를 넘기는 상황에서', () => {
+    it('variant props를 넘기면 컴포넌트에 반영된다', () => {
+      const { container } = renderInput({ variant: 'rect' });
+      expect(getByTestId(container, 'skeleton')).toHaveClass('rect');
+    });
+    it('animation props를 넘기면 컴포넌트에 반영된다', () => {
+      const { container } = renderInput({ animation: 'wave' });
+      expect(getByTestId(container, 'skeleton')).toHaveClass('wave');
+    });
+    it('size props를 넘기면 컴포넌트에 반영된다', () => {
+      const { container } = renderInput({ size: 'md' });
+      expect(getByTestId(container, 'skeleton')).toHaveClass('md');
+    });
+    it('children props를 넘기면 컴포넌트에 반영된다', () => {
+      const { container } = renderInput({ children: 'test' });
+      expect(getByTestId(container, 'skeleton')).toHaveTextContent('test');
+    });
+  });
+});

--- a/src/atom/Skeleton/index.tsx
+++ b/src/atom/Skeleton/index.tsx
@@ -37,7 +37,7 @@ const Skeleton = ({
       data-testid="skeleton"
       {...props}
     >
-      {children}
+      {withChildren && children}
     </div>
   );
 };

--- a/src/atom/Skeleton/index.tsx
+++ b/src/atom/Skeleton/index.tsx
@@ -1,0 +1,45 @@
+import React, { HTMLAttributes } from 'react';
+import cn from 'classnames';
+import './Skeleton.scss';
+import { customTypes } from 'custom-types';
+
+export interface SkeletonProps extends HTMLAttributes<HTMLDivElement> {
+  variant?: 'rect' | 'circle';
+  animation?: 'pulse' | 'wave' | 'false';
+  size?: customTypes.ElementSize;
+  width?: number | string;
+  height?: number | string;
+  fitContent?: boolean;
+  withChildren?: boolean;
+}
+
+const Skeleton = ({
+  variant = 'rect',
+  animation = 'wave',
+  size = 'md',
+  fitContent,
+  withChildren,
+  width,
+  height,
+  children,
+  ...props
+}: SkeletonProps) => {
+  return (
+    <div
+      className={cn('_SKELETON_', variant, animation, size, {
+        fitContent,
+        withChildren,
+      })}
+      style={{
+        width,
+        height,
+      }}
+      data-testid="skeleton"
+      {...props}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default Skeleton;

--- a/src/atom/Spinner/Spinner.scss
+++ b/src/atom/Spinner/Spinner.scss
@@ -1,0 +1,63 @@
+// Mixin
+// * $WH: width, height value (e.g. 16px)
+// * $Bsize: border-size value (e.g. 3px)
+// * $Bc0: border-color value (e.g. #fff)
+// * $Bc1: border-background-color value (e.g. #ffffff33)
+@mixin CustomSpin(
+  $WH: 16px,
+  $Bsize: 3px,
+  $Bc0: #fff,
+  $Bc1: rgba(255, 255, 255, 0.2)
+) {
+  width: $WH;
+  height: $WH;
+  border: $Bsize solid $Bc0;
+  margin: 0;
+  content: ' ';
+  display: block;
+  border-radius: 50%;
+  border-color: $Bc0 $Bc1 $Bc1 $Bc1;
+  animation: spin 1.15s cubic-bezier(0.31, 0.63, 0.8, 0.73) infinite;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+}
+
+._SPINNER_ {
+  @include CustomSpin($Bc0: $gray_7, $Bc1: $gray_2);
+
+  // Size
+  &.xxs {
+    @include CustomSpin(12px, 2px, $Bc0: $gray_7, $Bc1: $gray_2);
+  }
+
+  &.xs {
+    @include CustomSpin(14px, 2px, $Bc0: $gray_7, $Bc1: $gray_2);
+  }
+
+  &.sm {
+    @include CustomSpin(16px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+  }
+
+  &.md {
+    @include CustomSpin(18px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+  }
+
+  &.lg {
+    @include CustomSpin(24px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+  }
+
+  &.xl {
+    @include CustomSpin(28px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+  }
+
+  &.xxl {
+    @include CustomSpin(32px, 4px, $Bc0: $gray_7, $Bc1: $gray_2);
+  }
+}

--- a/src/atom/Spinner/Spinner.scss
+++ b/src/atom/Spinner/Spinner.scss
@@ -1,11 +1,11 @@
 // Mixin
-// * $WH: width, height value (e.g. 16px)
-// * $Bsize: border-size value (e.g. 3px)
+// * $WH: width, height value (e.g. 1.6rem)
+// * $Bsize: border-size value (e.g. 0.3rem)
 // * $Bc0: border-color value (e.g. #fff)
 // * $Bc1: border-background-color value (e.g. #ffffff33)
 @mixin CustomSpin(
-  $WH: 16px,
-  $Bsize: 3px,
+  $WH: 1.6rem,
+  $Bsize: 0.3rem,
   $Bc0: #fff,
   $Bc1: rgba(255, 255, 255, 0.2)
 ) {
@@ -34,30 +34,30 @@
 
   // Size
   &.xxs {
-    @include CustomSpin(12px, 2px, $Bc0: $gray_7, $Bc1: $gray_2);
+    @include CustomSpin(1.2rem, 0.2rem, $Bc0: $gray_7, $Bc1: $gray_2);
   }
 
   &.xs {
-    @include CustomSpin(14px, 2px, $Bc0: $gray_7, $Bc1: $gray_2);
+    @include CustomSpin(1.4rem, 0.2rem, $Bc0: $gray_7, $Bc1: $gray_2);
   }
 
   &.sm {
-    @include CustomSpin(16px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+    @include CustomSpin(1.6rem, 0.3rem, $Bc0: $gray_7, $Bc1: $gray_2);
   }
 
   &.md {
-    @include CustomSpin(18px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+    @include CustomSpin(1.8rem, 0.3rem, $Bc0: $gray_7, $Bc1: $gray_2);
   }
 
   &.lg {
-    @include CustomSpin(24px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+    @include CustomSpin(2.4rem, 0.3rem, $Bc0: $gray_7, $Bc1: $gray_2);
   }
 
   &.xl {
-    @include CustomSpin(28px, 3px, $Bc0: $gray_7, $Bc1: $gray_2);
+    @include CustomSpin(2.8rem, 0.3rem, $Bc0: $gray_7, $Bc1: $gray_2);
   }
 
   &.xxl {
-    @include CustomSpin(32px, 4px, $Bc0: $gray_7, $Bc1: $gray_2);
+    @include CustomSpin(3.2rem, 0.4rem, $Bc0: $gray_7, $Bc1: $gray_2);
   }
 }

--- a/src/atom/Spinner/Spinner.stories.tsx
+++ b/src/atom/Spinner/Spinner.stories.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Story, Meta } from '@storybook/react';
+import Spinner from '@src/atom/Spinner';
+
+export default {
+  title: 'Spinner',
+  component: Spinner,
+  argTypes: {
+    size: {
+      options: ['xxs', 'xs', 'sm', 'md', 'lg', 'xl', 'xxl'],
+      control: { type: 'radio' },
+    },
+  },
+} as Meta;
+
+const Template: Story = (props) => <Spinner {...props} />;
+
+export const spinner = Template.bind({});
+
+spinner.args = {
+  size: 'md',
+};

--- a/src/atom/Spinner/Spinner.test.tsx
+++ b/src/atom/Spinner/Spinner.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, getByTestId } from '@src/test-utils';
+import Spinner, { SpinnerProps } from '@src/atom/Spinner';
+
+function renderSpinner(props: SpinnerProps) {
+  return render(<Spinner {...props} />);
+}
+
+describe('<Spinner />', () => {
+  it('컴포넌트는 정상적으로 렌더링되어야 한다.', () => {
+    const { container } = renderSpinner({});
+    expect(container).toBeInTheDocument();
+  });
+
+  context('props를 넘기는 상황에서', () => {
+    it('size props를 넘기면 컴포넌트에 반영된다', () => {
+      const size = 'md';
+      const { container } = renderSpinner({ size });
+      expect(getByTestId(container, 'spinner')).toHaveClass('md');
+    });
+  });
+});

--- a/src/atom/Spinner/index.tsx
+++ b/src/atom/Spinner/index.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import cn from 'classnames';
+import './Spinner.scss';
+import { customTypes } from 'custom-types';
+
+export interface SpinnerProps {
+  size?: customTypes.ElementSize;
+}
+
+export const Spinner = ({ size = 'md', ...props }: SpinnerProps) => {
+  return (
+    <div className={cn('_SPINNER_', size)} {...props} data-testid="spinner" />
+  );
+};
+
+export default Spinner;


### PR DESCRIPTION
## Summary
공통으로 사용될 Skeleton 컴포넌트를 제작했습니다.

## Detail
[doodlin-design-system](https://github.com/doodlincorp/doodlin-design-system)을 참고해서 제작하되, 몇 가지 차별점을 두었습니다.
1. **`variant` props의 타입에서 `text`를 삭제했습니다.** `rect`가 `text`를 완전히 대체할 수 있기 때문입니다.
2. **Skeleton 컴포넌트가 `SkeletonBox`와 `SkeletonBtn`로 분리되어 있었는데, 불필요하다고 생각하여 통합하였습니다.**
3. **컴포넌트 크기를 width, height를 직접 지정하여 설정하는 방식만 지원하고 있었는데, size를 통해서 설정할 수 있도록 새로운 기능을 추가했습니다.** *(단, width/height를 지정한 크기가 있을 경우 이를 우선합니다.)* 저희가 `ElementSize`라는 사용자 설정 타입을 만든 만큼 이를 사용하면 좋겠다고 생각했기 때문입니다.

## Issue
* resolves #31 
* 컴포넌트 props가 사용자 정의 타입일 경우 스토리북의 Controls에서 radio를 통해 설정을 바꿀 수 없는 이슈가 있었습니다.
  * 스토리를 정의할 때 `argTypes`를 재정의하는 방식으로 해결했습니다. [#](https://storybook.js.org/docs/react/api/argtypes)

## Reference
[doodlin-design-system](https://github.com/doodlincorp/doodlin-design-system)
[ArgTypes - Storybook](https://storybook.js.org/docs/react/api/argtypes)