### PR TITLE
Button 컴포넌트 테스트 정상화 및 shadow props 추가

### DIFF
--- a/src/atom/Button/Button.scss
+++ b/src/atom/Button/Button.scss
@@ -193,6 +193,10 @@
     }
   }
 
+  &.shadow {
+    box-shadow: $box-shadow-1;
+  }
+
   .none {
     opacity: 0;
   }

--- a/src/atom/Button/Button.scss
+++ b/src/atom/Button/Button.scss
@@ -40,7 +40,6 @@
       padding: 0 0.8rem;
     }
   }
-
   &.xs {
     height: 2.8rem;
     padding: 0 0.8rem;
@@ -51,7 +50,6 @@
       padding: 0 1rem;
     }
   }
-
   &.sm {
     height: 3.2rem;
     padding: 0 1.2rem;
@@ -62,7 +60,6 @@
       padding: 0 1.4rem;
     }
   }
-
   &.md {
     height: 3.6rem;
     padding: 0 1.2rem;
@@ -73,7 +70,6 @@
       padding: 0 1.4rem;
     }
   }
-
   &.lg {
     height: 4.4rem;
     padding: 0 1.6rem;
@@ -113,20 +109,11 @@
     @include button-color();
   }
 
-  &.black {
-    &.ghost.loading {
-      background-color: $gray-8;
-    }
-  }
   &.blue {
     @include button-color($blue-5);
     &.ghost.lg,
     &.ghost.xl {
       border-width: 0.2rem;
-    }
-    &.ghost.loading,
-    &.quiet.loading {
-      background-color: $blue-5;
     }
   }
   &.red {
@@ -134,10 +121,6 @@
     &.ghost.lg,
     &.ghost.xl {
       border-width: 0.2rem;
-    }
-    &.ghost.loading,
-    &.quiet.loading {
-      background-color: $red-7;
     }
   }
   &.gray {
@@ -202,7 +185,7 @@
     }
   }
 
-  &.fullWidth {
+  &.full-width {
     width: 100%;
     margin: 0;
     & ~ & {

--- a/src/atom/Button/Button.stories.tsx
+++ b/src/atom/Button/Button.stories.tsx
@@ -17,6 +17,7 @@ button.args = {
   disabled: false,
   fullWidth: false,
   rounded: false,
+  shadow: false,
   buttonColor: 'black',
   labelText: 'TEST',
 };

--- a/src/atom/Button/Button.stories.tsx
+++ b/src/atom/Button/Button.stories.tsx
@@ -7,7 +7,6 @@ export default {
   component: Button,
 } as Meta;
 
-// eslint-disable-next-line react/jsx-props-no-spreading
 const Template: Story = (props) => <Button {...props} />;
 
 export const button = Template.bind({});

--- a/src/atom/Button/Button.test.tsx
+++ b/src/atom/Button/Button.test.tsx
@@ -4,7 +4,6 @@ import { render, getByTestId } from '@src/test-utils';
 import Button, { ButtonProps } from '@src/atom/Button';
 
 function renderButton(props: ButtonProps) {
-  // eslint-disable-next-line react/jsx-props-no-spreading
   return render(<Button {...props} />);
 }
 

--- a/src/atom/Button/Button.test.tsx
+++ b/src/atom/Button/Button.test.tsx
@@ -46,6 +46,11 @@ describe('<Button />', () => {
 
       expect(getByTestId(container, 'button')).toHaveClass('rounded');
     });
+    it('shadow props를 넘기면 컴포넌트에 반영된다', () => {
+      const { container } = renderButton({ shadow: true });
+
+      expect(getByTestId(container, 'button')).toHaveClass('shadow');
+    });
     it('buttonColor props를 넘기면 컴포넌트에 반영된다', () => {
       const { container } = renderButton({ buttonColor: 'gray' });
 

--- a/src/atom/Button/Button.test.tsx
+++ b/src/atom/Button/Button.test.tsx
@@ -18,27 +18,38 @@ describe('<Button />', () => {
       const className = 'amugeona';
 
       const { container } = renderButton({ className });
-      const button = getByTestId(container, 'button');
 
-      expect(button).toHaveClass(className);
+      expect(getByTestId(container, 'button')).toHaveClass(className);
     });
     it('size props를 넘기면 컴포넌트에 반영된다', () => {
-      //   const { container } = renderButton({ size: 'lg' });
+      const { container } = renderButton({ size: 'lg' });
+
+      expect(getByTestId(container, 'button')).toHaveClass('lg');
     });
     it('variant props를 넘기면 컴포넌트에 반영된다', () => {
-      //   const { container } = renderButton({ variant: 'solid' });
+      const { container } = renderButton({ variant: 'solid' });
+
+      expect(getByTestId(container, 'button')).toHaveClass('solid');
     });
     it('disabled props를 넘기면 컴포넌트에 반영된다', () => {
-      //   const { container } = renderButton({ disabled: true });
+      const { container } = renderButton({ disabled: true });
+
+      expect(getByTestId(container, 'button')).toHaveClass('disabled');
     });
     it('fullWidth props를 넘기면 컴포넌트에 반영된다', () => {
-      //   const { container } = renderButton({ fullWidth: true });
+      const { container } = renderButton({ fullWidth: true });
+
+      expect(getByTestId(container, 'button')).toHaveClass('full-width');
     });
     it('rounded props를 넘기면 컴포넌트에 반영된다', () => {
-      //   const { container } = renderButton({ rounded: true });
+      const { container } = renderButton({ rounded: true });
+
+      expect(getByTestId(container, 'button')).toHaveClass('rounded');
     });
     it('buttonColor props를 넘기면 컴포넌트에 반영된다', () => {
-      //   const { container } = renderButton({ buttonColor: true });
+      const { container } = renderButton({ buttonColor: 'gray' });
+
+      expect(getByTestId(container, 'button')).toHaveClass('gray');
     });
     it('disabled props를 넘기면 컴포넌트에 반영된다', () => {
       const labelText = 'hooker';

--- a/src/atom/Button/index.tsx
+++ b/src/atom/Button/index.tsx
@@ -34,7 +34,7 @@ const Button = ({
       className={cn(`_BUTTON_`, className, size, variant, buttonColor, {
         rounded,
         disabled,
-        fullWidth,
+        'full-width': fullWidth,
       })}
       disabled={disabled}
       {...restProps}

--- a/src/atom/Button/index.tsx
+++ b/src/atom/Button/index.tsx
@@ -37,7 +37,6 @@ const Button = ({
         fullWidth,
       })}
       disabled={disabled}
-      // eslint-disable-next-line react/jsx-props-no-spreading
       {...restProps}
     >
       <span>{labelText ? <>{labelText} </> : children}</span>

--- a/src/atom/Button/index.tsx
+++ b/src/atom/Button/index.tsx
@@ -12,6 +12,7 @@ export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   buttonColor?: ButtonColor;
   fullWidth?: boolean;
   rounded?: boolean;
+  shadow?: boolean;
   labelText?: string;
 }
 
@@ -23,6 +24,7 @@ const Button = ({
   disabled,
   fullWidth,
   rounded,
+  shadow,
   buttonColor = 'black',
   labelText,
   ...restProps
@@ -35,6 +37,7 @@ const Button = ({
         rounded,
         disabled,
         'full-width': fullWidth,
+        shadow,
       })}
       disabled={disabled}
       {...restProps}

--- a/src/atom/Icon/Icon.test.tsx
+++ b/src/atom/Icon/Icon.test.tsx
@@ -4,7 +4,6 @@ import { render, getByTestId } from '@src/test-utils';
 import Icon, { IconProps } from '@src/atom/Icon';
 
 function renderIcon(props: IconProps) {
-  // eslint-disable-next-line react/jsx-props-no-spreading
   return render(<Icon {...props} />);
 }
 

--- a/src/atom/Input/Input.stories.tsx
+++ b/src/atom/Input/Input.stories.tsx
@@ -7,7 +7,6 @@ export default {
   component: Input,
 } as Meta;
 
-// eslint-disable-next-line react/jsx-props-no-spreading
 const Template: Story = (props) => <Input {...props} />;
 
 export const input = Template.bind({});

--- a/src/atom/Input/Input.test.tsx
+++ b/src/atom/Input/Input.test.tsx
@@ -4,7 +4,6 @@ import { render, getByTestId } from '@src/test-utils';
 import Input, { InputProps } from '@src/atom/Input';
 
 function renderInput(props: InputProps) {
-  // eslint-disable-next-line react/jsx-props-no-spreading
   return render(<Input {...props} />);
 }
 

--- a/src/styles/_color.scss
+++ b/src/styles/_color.scss
@@ -11,6 +11,7 @@ $blue_8: #003267;
 
 // Gray
 $white: #fff;
+$black: #000;
 $gray_0: #f9f9fb;
 $gray_1: #efeff2;
 $gray_2: #ebebee;

--- a/src/styles/_variable.scss
+++ b/src/styles/_variable.scss
@@ -14,3 +14,5 @@ $font-size-xxx-large: 3.6rem;
 $font-size-xxxx-large: 4.8rem;
 
 $button-hover-transition: ease-out 0.1s;
+
+$box-shadow-1: 0 0.5rem 1rem rgba($black, 0.15);


### PR DESCRIPTION
## Summary
Button 컴포넌트의 테스트를 정상화  하였으며, shadow props를 추가하였습니다.

## Detail
### react/jsx-props-no-spreading ignore 주석을 제거 9049d92
### Button 컴포넌트에서 스타일 검사하는 부분을 클래스를 검사하도록 변경 33a6b2b
### Button 컴포넌트 sass 카멜컨벤션을 스네이크 컨벤션으로 변경 4c27a6d
### Button 컴포넌트에 shadow props를 추가 8a55ec7
